### PR TITLE
Set a new root controller for a UINavigationController

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,6 +118,26 @@ var Controllers = {
       pop: function (params) {
         RCCManager.NavigationControllerIOS(id, "pop", params);
       },
+      setRootController: function (params) {
+        var unsubscribes = [];
+        if (params['style']) {
+          _processProperties(params['style']);
+        }
+        if (params['leftButtons']) {
+          var unsubscribe = _processButtons(params['leftButtons']);
+          unsubscribes.push(unsubscribe);
+        }
+        if (params['rightButtons']) {
+          var unsubscribe = _processButtons(params['rightButtons']);
+          unsubscribes.push(unsubscribe);
+        }
+        RCCManager.NavigationControllerIOS(id, "setRootController", params);
+        return function() {
+          for (var i = 0 ; i < unsubscribes.length ; i++) {
+            if (unsubscribes[i]) { unsubscribes[i](); }
+          }
+        };
+      },
       setLeftButton: function () {
         console.error('setLeftButton is deprecated, see setLeftButtons');
       },

--- a/ios/RCCNavigationController.m
+++ b/ios/RCCNavigationController.m
@@ -107,6 +107,38 @@ NSString const *CALLBACK_ASSOCIATED_ID = @"RCCNavigationController.CALLBACK_ASSO
     [self popViewControllerAnimated:animated];
     return;
   }
+  
+  // setRootController
+  if ([performAction isEqualToString:@"setRootController"])
+  {
+    NSString *component = actionParams[@"component"];
+    if (!component) return;
+    
+    NSDictionary *passProps = actionParams[@"passProps"];
+    NSDictionary *navigatorStyle = actionParams[@"style"];
+    
+    RCCViewController *viewController = [[RCCViewController alloc] initWithComponent:component passProps:passProps navigatorStyle:navigatorStyle bridge:bridge];
+    
+    NSString *title = actionParams[@"title"];
+    if (title) viewController.title = title;
+    
+    NSArray *leftButtons = actionParams[@"leftButtons"];
+    if (leftButtons)
+    {
+      [self setButtons:leftButtons viewController:viewController side:@"left" animated:NO];
+    }
+    
+    NSArray *rightButtons = actionParams[@"rightButtons"];
+    if (rightButtons)
+    {
+      [self setButtons:rightButtons viewController:viewController side:@"right" animated:NO];
+    }
+    
+    BOOL animated = actionParams[@"animated"] ? [actionParams[@"animated"] boolValue] : YES;
+    
+    [self setViewControllers:@[viewController] animated:animated];
+    return;
+  }
 
   // setButtons
   if ([performAction isEqualToString:@"setButtons"])


### PR DESCRIPTION
Put together a quick solution for this. 

```
    Controllers.NavigationControllerIOS("movies").setRootController({
      title: "Other Navigation Root",
      component: 'NewNavigationRoot',
      animated: true,
    });
```

My use case only allows resetting the Navigation stack to a single view controller. 
Do you think we should support setting multiple controllers?  
