### PR TITLE
Pass launchOptions via RCCManager

### DIFF
--- a/example/ios/ControllersExample/AppDelegate.m
+++ b/example/ios/ControllersExample/AppDelegate.m
@@ -35,8 +35,10 @@
 
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
   self.window.backgroundColor = [UIColor whiteColor];
-  [[RCCManager sharedInstance] initBridgeWithBundleURL:jsCodeLocation];
-  
+  [[RCCManager sharedIntance] initBridgeWithBundleURL:jsCodeLocation
+                                        launchOptions:launchOptions];
+
+
   return YES;
 }
 

--- a/ios/RCCManager.h
+++ b/ios/RCCManager.h
@@ -7,7 +7,7 @@
 + (instancetype)sharedInstance;
 + (instancetype)sharedIntance;
 
--(void)initBridgeWithBundleURL:(NSURL *)bundleURL;
+-(void)initBridgeWithBundleURL:(NSURL *)bundleURL launchOptions:(NSDictionary *)launchOptions;
 -(RCTBridge*)getBridge;
 -(UIWindow*)getAppWindow;
 

--- a/ios/RCCManager.m
+++ b/ios/RCCManager.m
@@ -116,13 +116,13 @@
   return component;
 }
 
--(void)initBridgeWithBundleURL:(NSURL *)bundleURL
+-(void)initBridgeWithBundleURL:(NSURL *)bundleURL launchOptions:(NSDictionary *)launchOptions
 {
   if (self.sharedBridge) return;
   
   self.bundleURL = bundleURL;
-  self.sharedBridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:nil];
-  
+  self.sharedBridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
+
   [self showSplashScreen];
 }
 


### PR DESCRIPTION
It fixes the issue that methods `React.Linking.getInitialURL()` and `React.PushNotificationIOS.popInitialNotification()` were not working because `launchOptions` were not passed to initialization of an app.
