### PR TITLE
added support for tabBarItem.titlePositionAdjustment 

### DIFF
--- a/README.md
+++ b/README.md
@@ -782,7 +782,8 @@ All styles are optional, this is the format of the style object:
 {
   tabBarButtonColor: '#ffff00', // change the color of the tab icons and text (also unselected)
   tabBarSelectedButtonColor: '#ff9900', // change the color of the selected tab icon and text (only selected)
-  tabBarBackgroundColor: '#551A8B' // change the background color of the tab bar
+  tabBarBackgroundColor: '#551A8B', // change the background color of the tab bar
+  tabBarTextAdjustment: { x: 0, y: 0 } // change the text x and y offset
 }
 ```
 

--- a/ios/RCCManager.h
+++ b/ios/RCCManager.h
@@ -7,7 +7,7 @@
 + (instancetype)sharedInstance;
 + (instancetype)sharedIntance;
 
--(void)initBridgeWithBundleURL:(NSURL *)bundleURL;
+-(void)initBridgeWithBundleURL:(NSURL *)bundleURL launchOptions:(NSDictionary *)launchOptions;
 -(RCTBridge*)getBridge;
 
 -(void)registerController:(UIViewController*)controller componentId:(NSString*)componentId componentType:(NSString*)componentType;

--- a/ios/RCCManager.m
+++ b/ios/RCCManager.m
@@ -116,12 +116,12 @@
   return component;
 }
 
--(void)initBridgeWithBundleURL:(NSURL *)bundleURL
+-(void)initBridgeWithBundleURL:(NSURL *)bundleURL launchOptions:(NSDictionary *)launchOptions
 {
   if (self.sharedBridge) return;
   
   self.bundleURL = bundleURL;
-  self.sharedBridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:nil];
+  self.sharedBridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
   
   [self showSplashScreen];
 }

--- a/ios/RCCManagerModule.m
+++ b/ios/RCCManagerModule.m
@@ -259,6 +259,8 @@ showController:(NSDictionary*)layout animationType:(NSString*)animationType glob
                                                 error:[RCCManagerModule rccErrorWithCode:RCCManagerModuleCantCreateControllerErrorCode description:@"could not create controller"]];
         return;
     }
+    
+    [controller setModalPresentationStyle:UIModalPresentationCustom];
 
     [[RCCManagerModule lastModalPresenterViewController] presentViewController:controller
                                                            animated:![animationType isEqualToString:@"none"]

--- a/ios/RCCNavigationController.m
+++ b/ios/RCCNavigationController.m
@@ -292,4 +292,26 @@ NSString const *CALLBACK_ASSOCIATED_ID = @"RCCNavigationController.CALLBACK_ASSO
   }
 }
 
+-(BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation
+{
+  return [self.topViewController shouldAutorotateToInterfaceOrientation:interfaceOrientation];
+}
+
+-(UIInterfaceOrientationMask)supportedInterfaceOrientations
+{
+  if (self.topViewController) {
+    return [self.topViewController supportedInterfaceOrientations];
+  }
+  
+  return UIInterfaceOrientationMaskPortrait;
+}
+
+-(BOOL)shouldAutorotate
+{
+  if (self.topViewController) {
+    return [self.topViewController shouldAutorotate];
+  }
+  return NO;
+}
+
 @end

--- a/ios/RCCTabBarController.h
+++ b/ios/RCCTabBarController.h
@@ -7,3 +7,9 @@
 - (void)performAction:(NSString*)performAction actionParams:(NSDictionary*)actionParams bridge:(RCTBridge *)bridge completion:(void (^)(void))completion;
 
 @end
+
+@interface RCCTabBarController (UITabBarDelegate) <UITabBarDelegate>
+- (void)tabBar:(UITabBar *)tabBar didSelectItem:(UITabBarItem *)item;
+
+@end
+

--- a/ios/RCCTabBarController.m
+++ b/ios/RCCTabBarController.m
@@ -2,6 +2,7 @@
 #import "RCCViewController.h"
 #import "RCTConvert.h"
 #import "RCCManager.h"
+#import "RCTEventDispatcher.h"
 
 @implementation RCCTabBarController
 
@@ -225,3 +226,18 @@
 }
 
 @end
+
+@implementation RCCTabBarController (UITabBarDelegate)
+
+- (void)tabBar:(UITabBar *)tabBar didSelectItem:(UITabBarItem *)item {
+  
+  [[[RCCManager sharedInstance] getBridge].eventDispatcher sendAppEventWithName:@"tabbarControllerEventID" body:@
+   {
+     @"type": @"TabBarButtonPress",
+     @"id": @(item.tag),
+     @"label": item.title,
+   }];
+}
+
+@end
+

--- a/ios/RCCTabBarController.m
+++ b/ios/RCCTabBarController.m
@@ -3,6 +3,7 @@
 #import "RCTConvert.h"
 #import "RCCManager.h"
 #import "RCTEventDispatcher.h"
+#import "RCCNavigationController.h"
 
 @implementation RCCTabBarController
 
@@ -223,6 +224,26 @@
     {
       completion();
     }
+}
+
+-(BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation {
+  return [self.selectedViewController shouldAutorotateToInterfaceOrientation:interfaceOrientation];
+}
+
+-(UIInterfaceOrientationMask)supportedInterfaceOrientations {
+  if (self.selectedViewController) {
+    return [self.selectedViewController supportedInterfaceOrientations];
+  }
+  
+  return UIInterfaceOrientationMaskPortrait;
+}
+
+-(BOOL)shouldAutorotate {
+  RCCNavigationController *navVC = (id)self.selectedViewController;
+  if ([navVC isKindOfClass:[RCCNavigationController class]]) {
+    return navVC.shouldAutorotate;
+  }
+  return NO;
 }
 
 @end

--- a/ios/RCCTabBarController.m
+++ b/ios/RCCTabBarController.m
@@ -106,6 +106,14 @@
        @{NSForegroundColorAttributeName : selectedButtonColor} forState:UIControlStateSelected];
     }
     
+    // adject text position
+    NSDictionary *tabBarTextAdjustment = tabsStyle[@"tabBarTextAjustment"];
+    if(tabBarTextAdjustment &&
+       [tabBarTextAdjustment objectForKey:@"x"] &&
+       [tabBarTextAdjustment objectForKey:@"y"]) {
+      viewController.tabBarItem.titlePositionAdjustment = UIOffsetMake([[tabBarTextAdjustment objectForKey:@"x"] integerValue], [[tabBarTextAdjustment objectForKey:@"y"] integerValue]);
+    }
+    
     // create badge
     NSObject *badge = tabItemLayout[@"props"][@"badge"];
     if (badge == nil || [badge isEqual:[NSNull null]])

--- a/ios/RCCTabBarController.m
+++ b/ios/RCCTabBarController.m
@@ -107,7 +107,7 @@
     }
     
     // adject text position
-    NSDictionary *tabBarTextAdjustment = tabsStyle[@"tabBarTextAjustment"];
+    NSDictionary *tabBarTextAdjustment = tabsStyle[@"tabBarTextAdjustment"];
     if(tabBarTextAdjustment &&
        [tabBarTextAdjustment objectForKey:@"x"] &&
        [tabBarTextAdjustment objectForKey:@"y"]) {

--- a/ios/RCCViewController.h
+++ b/ios/RCCViewController.h
@@ -5,6 +5,7 @@
 
 @property (nonatomic) NSMutableDictionary *navigatorStyle;
 @property (nonatomic) BOOL navBarHidden;
+@property (nonatomic) BOOL shouldAutoRotate;
 
 + (UIViewController*)controllerWithLayout:(NSDictionary *)layout globalProps:(NSDictionary *)globalProps bridge:(RCTBridge *)bridge;
 

--- a/ios/RCCViewController.m
+++ b/ios/RCCViewController.m
@@ -120,6 +120,17 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
   
   RCTRootView *reactView = [[RCTRootView alloc] initWithBridge:bridge moduleName:component initialProperties:mergedProps];
   if (!reactView) return nil;
+  
+  // Set custom background color
+  id backgroundColor = navigatorStyle[@"backgroundColor"];
+  if (backgroundColor) {
+    if (backgroundColor == 0) {
+      [reactView setBackgroundColor:[UIColor clearColor]];
+    } else {
+      UIColor *bgColor = [RCTConvert UIColor:backgroundColor];
+      [reactView setBackgroundColor:bgColor];
+    }
+  }
 
   self = [super init];
   if (!self) return nil;

--- a/ios/RCCViewController.m
+++ b/ios/RCCViewController.m
@@ -136,6 +136,10 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
   if (!self) return nil;
 
   [self commonInit:reactView navigatorStyle:navigatorStyle props:passProps];
+  
+  NSNumber *shouldAutoRotate = navigatorStyle[@"shouldAutoRotate"];
+  BOOL shouldAutoRotateBool = shouldAutoRotate ? [shouldAutoRotate boolValue] : NO;
+  self.shouldAutoRotate = shouldAutoRotateBool;
 
   return self;
 }
@@ -511,6 +515,21 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
       NSLog(@"addExternalVCIfNecessary: could not create class from string. Check that the proper class name wass passed in ExternalNativeScreenClass");
     }
   }
+}
+
+- (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation
+{
+  return (interfaceOrientation == UIInterfaceOrientationPortrait) || (interfaceOrientation == UIInterfaceOrientationIsLandscape);
+}
+
+- (BOOL)shouldAutorotate
+{
+  return self.shouldAutoRotate;
+}
+
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations
+{
+  return UIInterfaceOrientationMaskPortrait | UIInterfaceOrientationMaskLandscape;
 }
 
 @end

--- a/ios/RCCViewController.m
+++ b/ios/RCCViewController.m
@@ -124,7 +124,7 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
   // Set custom background color
   id backgroundColor = navigatorStyle[@"backgroundColor"];
   if (backgroundColor) {
-    if (backgroundColor == 0) {
+    if ([backgroundColor isEqual:@0]) {
       [reactView setBackgroundColor:[UIColor clearColor]];
     } else {
       UIColor *bgColor = [RCTConvert UIColor:backgroundColor];


### PR DESCRIPTION
This adds an easy way to reposition the text label in a UITabBarItem. Great if you don't show an icon in your tab and what to center the text vertically.
