### PR TITLE
Add programmatic control of TabBar upper border.

### DIFF
--- a/ios/RCCTabBarController.m
+++ b/ios/RCCTabBarController.m
@@ -27,10 +27,11 @@
   if (!self) return nil;
 
   self.tabBar.translucent = YES; // default
-  
+
   UIColor *buttonColor = nil;
   UIColor *selectedButtonColor = nil;
   NSDictionary *tabsStyle = props[@"style"];
+
   if (tabsStyle)
   {
     NSString *tabBarButtonColor = tabsStyle[@"tabBarButtonColor"];
@@ -100,6 +101,10 @@
 
     viewController.tabBarItem = [[UITabBarItem alloc] initWithTitle:title image:iconImage tag:0];
     viewController.tabBarItem.selectedImage = iconImageSelected;
+
+    if (!title) {
+      viewController.tabBarItem.imageInsets = UIEdgeInsetsMake(5.5, 0, -5.5, 0);
+    }
 
     if (buttonColor)
     {

--- a/ios/RCCTabBarController.m
+++ b/ios/RCCTabBarController.m
@@ -25,7 +25,7 @@
 {
   self = [super init];
   if (!self) return nil;
-  
+
   self.tabBar.translucent = YES; // default
   
   UIColor *buttonColor = nil;
@@ -41,7 +41,14 @@
       buttonColor = color;
       selectedButtonColor = color;
     }
-    
+
+    BOOL *hideTabBarSeperator = tabsStyle[@"hideTabBarSeperator"] ? [tabsStyle[@"hideTabBarSeperator"] boolValue] : NO;
+    if (hideTabBarSeperator)
+    {
+      [[UITabBar appearance] setShadowImage:nil];
+      [self.tabBar setValue:@(YES) forKeyPath:@"_hidesShadow"];
+    }
+
     NSString *tabBarSelectedButtonColor = tabsStyle[@"tabBarSelectedButtonColor"];
     if (tabBarSelectedButtonColor)
     {
@@ -49,7 +56,7 @@
       self.tabBar.tintColor = color;
       selectedButtonColor = color;
     }
-    
+
     NSString *tabBarBackgroundColor = tabsStyle[@"tabBarBackgroundColor"];
     if (tabBarBackgroundColor)
     {
@@ -93,19 +100,19 @@
 
     viewController.tabBarItem = [[UITabBarItem alloc] initWithTitle:title image:iconImage tag:0];
     viewController.tabBarItem.selectedImage = iconImageSelected;
-    
+
     if (buttonColor)
     {
       [viewController.tabBarItem setTitleTextAttributes:
        @{NSForegroundColorAttributeName : buttonColor} forState:UIControlStateNormal];
     }
-    
+
     if (selectedButtonColor)
     {
       [viewController.tabBarItem setTitleTextAttributes:
        @{NSForegroundColorAttributeName : selectedButtonColor} forState:UIControlStateSelected];
     }
-    
+
     // create badge
     NSObject *badge = tabItemLayout[@"props"][@"badge"];
     if (badge == nil || [badge isEqual:[NSNull null]])
@@ -135,7 +142,7 @@
       if (tabIndex)
       {
         int i = (int)[tabIndex integerValue];
-      
+
         if ([self.viewControllers count] > i)
         {
           viewController = [self.viewControllers objectAtIndex:i];
@@ -147,11 +154,11 @@
       {
         viewController = [[RCCManager sharedInstance] getControllerWithId:contentId componentType:contentType];
       }
-      
+
       if (viewController)
       {
         NSObject *badge = actionParams[@"badge"];
-        
+
         if (badge == nil || [badge isEqual:[NSNull null]])
         {
           viewController.tabBarItem.badgeValue = nil;
@@ -162,7 +169,7 @@
         }
       }
     }
-  
+
     if ([performAction isEqualToString:@"switchTo"])
     {
       UIViewController *viewController = nil;
@@ -170,7 +177,7 @@
       if (tabIndex)
       {
         int i = (int)[tabIndex integerValue];
-      
+
         if ([self.viewControllers count] > i)
         {
           viewController = [self.viewControllers objectAtIndex:i];
@@ -182,7 +189,7 @@
       {
         viewController = [[RCCManager sharedInstance] getControllerWithId:contentId componentType:contentType];
       }
-    
+
       if (viewController)
       {
         [self setSelectedViewController:viewController];


### PR DESCRIPTION
Adds two improvements:
1. Optional removal of TabBar upper border with the `tabsStyle` property `hideTabBarSeperator: true` - without using transparent images.
2. Correct positioning of TabBarItem icons when no label is set for an item. Without this, the icons are too high. With this, they are vertically centred in a the tab bar.
