### PR TITLE
Adds initial properties and launch properties to RCCManager

### DIFF
--- a/ios/RCCManager.h
+++ b/ios/RCCManager.h
@@ -7,6 +7,7 @@
 + (instancetype)sharedInstance;
 + (instancetype)sharedIntance;
 
+-(void)initBridgeWithBundleURL:(NSURL *)bundleURL initialProps:(NSDictionary *)initialProps launchOptions:(NSDictionary *)launchOptions;
 -(void)initBridgeWithBundleURL:(NSURL *)bundleURL;
 -(RCTBridge*)getBridge;
 
@@ -15,5 +16,7 @@
 -(void)unregisterController:(UIViewController*)vc;
 
 -(void)clearModuleRegistry;
+
+@property (nonatomic, strong) NSDictionary *initialProps;
 
 @end

--- a/ios/RCCManager.m
+++ b/ios/RCCManager.m
@@ -118,10 +118,16 @@
 
 -(void)initBridgeWithBundleURL:(NSURL *)bundleURL
 {
+  [self initBridgeWithBundleURL:bundleURL initialProps:nil launchOptions:nil];
+}
+
+-(void)initBridgeWithBundleURL:(NSURL *)bundleURL initialProps:(NSDictionary *)initialProps launchOptions:(NSDictionary *)launchOptions
+{
   if (self.sharedBridge) return;
   
   self.bundleURL = bundleURL;
-  self.sharedBridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:nil];
+  self.sharedBridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
+  self.initialProps = initialProps;
   
   [self showSplashScreen];
 }

--- a/ios/RCCViewController.m
+++ b/ios/RCCViewController.m
@@ -102,6 +102,10 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
   NSMutableDictionary *mergedProps = [NSMutableDictionary dictionaryWithDictionary:globalProps];
   [mergedProps addEntriesFromDictionary:passProps];
   
+  if ([RCCManager sharedInstance].initialProps) {
+    [mergedProps addEntriesFromDictionary:[RCCManager sharedIntance].initialProps];
+  }
+  
   RCTRootView *reactView = [[RCTRootView alloc] initWithBridge:bridge moduleName:component initialProperties:mergedProps];
   if (!reactView) return nil;
 
@@ -117,6 +121,10 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
 {
   NSMutableDictionary *mergedProps = [NSMutableDictionary dictionaryWithDictionary:globalProps];
   [mergedProps addEntriesFromDictionary:passProps];
+  
+  if ([RCCManager sharedInstance].initialProps) {
+    [mergedProps addEntriesFromDictionary:[RCCManager sharedIntance].initialProps];
+  }
   
   RCTRootView *reactView = [[RCTRootView alloc] initWithBridge:bridge moduleName:component initialProperties:mergedProps];
   if (!reactView) return nil;


### PR DESCRIPTION
Adds ability to launch RCTRootView with initial properties via a dictionary on the shared RCCManager

Adds ability to send launchOptions into RCCManager, see #55 
