### PR TITLE
Register custom transitioning delegates for modal presentation

### DIFF
--- a/ios/RCCManager.h
+++ b/ios/RCCManager.h
@@ -16,4 +16,7 @@
 
 -(void)clearModuleRegistry;
 
+- (id<UIViewControllerTransitioningDelegate>) getModalTransitioningDelegateForId:(NSString*) delegateId;
+- (void)registerModalTransitioningDelegate:(id<UIViewControllerTransitioningDelegate>)delegate forDelegateId:(NSString *) component;
+
 @end

--- a/ios/RCCManager.m
+++ b/ios/RCCManager.m
@@ -7,7 +7,7 @@
 @property (nonatomic, strong) NSMutableDictionary *modulesRegistry;
 @property (nonatomic, strong) RCTBridge *sharedBridge;
 @property (nonatomic, strong) NSURL *bundleURL;
-@property (nonatomic, strong) NSMutableDictionary<String,id<UIViewControllerTransitioningDelegate>> *componentToModalTransitioningDelegate;
+@property (nonatomic, strong) NSMutableDictionary<String,id<UIViewControllerTransitioningDelegate>> *modalTransitioningDelegateRegistry;
 @end
 
 @implementation RCCManager
@@ -210,13 +210,13 @@
 #pragma mark - custom transitioning delegates
 
 - (id<UIViewControllerTransitioningDelegate>) getModalTransitioningDelegateForId:(NSString*) delegateId {
-    return [self.componentToModalTransitioningDelegate objectForKey:delegateId];
+    return [self.modalTransitioningDelegateRegistry objectForKey:delegateId];
 }
 - (void)registerModalTransitioningDelegate:(id<UIViewControllerTransitioningDelegate>)delegate forDelegateId:(NSString *) component {
-    if (self.componentToModalTransitioningDelegate == nil) {
-        self.componentToModalTransitioningDelegate = [NSMutableDictionary dictionary];
+    if (self.modalTransitioningDelegateRegistry == nil) {
+        self.modalTransitioningDelegateRegistry = [NSMutableDictionary dictionary];
     }
-    self.componentToModalTransitioningDelegate[component] = delegate;
+    self.modalTransitioningDelegateRegistry[component] = delegate;
 }
 
 @end

--- a/ios/RCCManager.m
+++ b/ios/RCCManager.m
@@ -7,6 +7,7 @@
 @property (nonatomic, strong) NSMutableDictionary *modulesRegistry;
 @property (nonatomic, strong) RCTBridge *sharedBridge;
 @property (nonatomic, strong) NSURL *bundleURL;
+@property (nonatomic, strong) NSMutableDictionary<String,id<UIViewControllerTransitioningDelegate>> *componentToModalTransitioningDelegate;
 @end
 
 @implementation RCCManager
@@ -204,6 +205,18 @@
 - (NSURL *)sourceURLForBridge:(RCTBridge *)bridge
 {
   return self.bundleURL;
+}
+
+#pragma mark - custom transitioning delegates
+
+- (id<UIViewControllerTransitioningDelegate>) getModalTransitioningDelegateForId:(NSString*) delegateId {
+    return [self.componentToModalTransitioningDelegate objectForKey:delegateId];
+}
+- (void)registerModalTransitioningDelegate:(id<UIViewControllerTransitioningDelegate>)delegate forDelegateId:(NSString *) component {
+    if (self.componentToModalTransitioningDelegate == nil) {
+        self.componentToModalTransitioningDelegate = [NSMutableDictionary dictionary];
+    }
+    self.componentToModalTransitioningDelegate[component] = delegate;
 }
 
 @end

--- a/ios/RCCManagerModule.m
+++ b/ios/RCCManagerModule.m
@@ -259,6 +259,10 @@ showController:(NSDictionary*)layout animationType:(NSString*)animationType glob
                                                 error:[RCCManagerModule rccErrorWithCode:RCCManagerModuleCantCreateControllerErrorCode description:@"could not create controller"]];
         return;
     }
+    
+    if ([animationType isEqualToString:@"custom"]) {
+        [RCCManagerModule applyCustomTransitioningDelegateTo:controller withProps:layout[@"props"]];
+    }
 
     [[RCCManagerModule lastModalPresenterViewController] presentViewController:controller
                                                            animated:![animationType isEqualToString:@"none"]
@@ -307,6 +311,19 @@ dismissAllControllers:(NSString*)animationType resolver:(RCTPromiseResolveBlock)
     else
     {
         [self dismissAllModalPresenters:allPresentedViewControllers resolver:resolve];
+    }
+}
+
+#pragma mark - support for custom transitioning delegates
+
++ (void)applyCustomTransitioningDelegateTo:(UIViewController *)controller withProps:(NSDictionary *)props {
+    // set a custom transitioning delegate
+    NSDictionary *passProps = props[@"passProps"];
+    NSString *delegateId = passProps[@"transitioningDelegateId"];
+    id<UIViewControllerTransitioningDelegate> delegate = [[RCCManager sharedInstance] getModalTransitioningDelegateForId:delegateId];
+    if (delegate != nil) {
+        controller.modalPresentationStyle = UIModalPresentationCustom;
+        controller.transitioningDelegate = delegate;
     }
 }
 


### PR DESCRIPTION
This adds support for custom modal transitioning delegates to be registered in the `RCCManager`.

In the `passProps` of the call to show the modal controller, pass in a `transitioningDelegateId` previously registered on the `RCCManager`. Additionally, make sure `animationType` is passed in as `'custom'`.

This transitioningDelegate is then applied as the `UIViewController.transitioningDelegate` and its `modalPresentationStyle` is set to `UIModalPresentationCustom`.
