### PR TITLE
iOS 7 compatibility

### DIFF
--- a/ios/RCCLightBox.m
+++ b/ios/RCCLightBox.m
@@ -29,7 +29,8 @@ const NSInteger kLightBoxTag = 0x101010;
         if (self.params != nil && style != nil)
         {
             
-            if (style[@"backgroundBlur"] != nil && ![style[@"backgroundBlur"] isEqualToString:@"none"])
+            if (style[@"backgroundBlur"] != nil && ![style[@"backgroundBlur"] isEqualToString:@"none"] && [UIVisualEffectView class])
+                                                                                                           
             {
                 self.visualEffectView = [[UIVisualEffectView alloc] init];
                 self.visualEffectView.frame = CGRectMake(0, 0, frame.size.width, frame.size.height);
@@ -96,23 +97,30 @@ const NSInteger kLightBoxTag = 0x101010;
     }
 }
 
--(UIBlurEffect*)blurEfectForCurrentStyle
+-(NSObject*)blurEffectForCurrentStyle
 {
-    NSDictionary *style = self.params[@"style"];
-    NSString *backgroundBlur = style[@"backgroundBlur"];
-    if ([backgroundBlur isEqualToString:@"none"])
+    if ([UIBlurEffect class])
+    {
+        NSDictionary *style = self.params[@"style"];
+        NSString *backgroundBlur = style[@"backgroundBlur"];
+        if ([backgroundBlur isEqualToString:@"none"])
+        {
+            return nil;
+        }
+        
+        UIBlurEffectStyle blurEffectStyle = UIBlurEffectStyleDark;
+        if ([backgroundBlur isEqualToString:@"light"])
+            blurEffectStyle = UIBlurEffectStyleLight;
+        else if ([backgroundBlur isEqualToString:@"xlight"])
+            blurEffectStyle = UIBlurEffectStyleExtraLight;
+        else if ([backgroundBlur isEqualToString:@"dark"])
+            blurEffectStyle = UIBlurEffectStyleDark;
+        return [UIBlurEffect effectWithStyle:blurEffectStyle];
+    }
+    else
     {
         return nil;
     }
-    
-    UIBlurEffectStyle blurEffectStyle = UIBlurEffectStyleDark;
-    if ([backgroundBlur isEqualToString:@"light"])
-        blurEffectStyle = UIBlurEffectStyleLight;
-    else if ([backgroundBlur isEqualToString:@"xlight"])
-        blurEffectStyle = UIBlurEffectStyleExtraLight;
-    else if ([backgroundBlur isEqualToString:@"dark"])
-        blurEffectStyle = UIBlurEffectStyleDark;
-    return [UIBlurEffect effectWithStyle:blurEffectStyle];
 }
 
 -(void)showAnimated
@@ -123,7 +131,7 @@ const NSInteger kLightBoxTag = 0x101010;
          {
              if (self.visualEffectView != nil)
              {
-                 self.visualEffectView.effect = [self blurEfectForCurrentStyle];
+                 self.visualEffectView.effect = [self blurEffectForCurrentStyle];
              }
              
              if (self.overlayColorView != nil)

--- a/ios/RCCViewController.m
+++ b/ios/RCCViewController.m
@@ -237,18 +237,21 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
     
     NSNumber *navBarHideOnScroll = self.navigatorStyle[@"navBarHideOnScroll"];
     BOOL navBarHideOnScrollBool = navBarHideOnScroll ? [navBarHideOnScroll boolValue] : NO;
-    if (navBarHideOnScrollBool)
+    if ([viewController.navigationController respondsToSelector:@selector(hidesBarsOnSwipe)])
     {
+      if (navBarHideOnScrollBool)
+      {
         viewController.navigationController.hidesBarsOnSwipe = YES;
-    }
-    else
-    {
+      }
+      else
+      {
         viewController.navigationController.hidesBarsOnSwipe = NO;
+      }
     }
     
     NSNumber *statusBarBlur = self.navigatorStyle[@"statusBarBlur"];
     BOOL statusBarBlurBool = statusBarBlur ? [statusBarBlur boolValue] : NO;
-    if (statusBarBlurBool)
+    if (statusBarBlurBool && [UIBlurEffect class])
     {
         if (![viewController.view viewWithTag:BLUR_STATUS_TAG])
         {
@@ -258,10 +261,11 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
             [viewController.view addSubview:blur];
         }
     }
-    
+  
     NSNumber *navBarBlur = self.navigatorStyle[@"navBarBlur"];
     BOOL navBarBlurBool = navBarBlur ? [navBarBlur boolValue] : NO;
-    if (navBarBlurBool)
+  
+    if (navBarBlurBool && [UIBlurEffect class])
     {
         if (![viewController.navigationController.navigationBar viewWithTag:BLUR_NAVBAR_TAG])
         {


### PR DESCRIPTION
Check for existence of iOS 8 classes `UIBlurEffect` and `UIVisualEffectView`, as well as `hidesBarsOnSwipe` property. Blur effect is turned off if these classes are not available.

Also a minor typo fix.

**Note**: to get this to run on an iOS 7 device I had to add UIKit as an **Optional** framework in "Link Binary With Libraries"
