### PR TITLE
Add setTitleImage to API

### DIFF
--- a/index.js
+++ b/index.js
@@ -163,6 +163,9 @@ var Controllers = {
       setTitle: function (params) {
         RCCManager.NavigationControllerIOS(id, "setTitle", params);
       },
+      setTitleImage: function (params) {
+        RCCManager.NavigationControllerIOS(id, "setTitleImage", params);
+      },
       resetTo: function (params) {
         var unsubscribes = [];
         if (params['style']) {

--- a/ios/RCCNavigationController.m
+++ b/ios/RCCNavigationController.m
@@ -23,7 +23,7 @@ NSString const *CALLBACK_ASSOCIATED_ID = @"RCCNavigationController.CALLBACK_ASSO
   NSString *title = props[@"title"];
   if (title) viewController.title = title;
   
-  [self setTitleIamgeForVC:viewController titleImageData:props[@"titleImage"]];
+  [self setTitleImageForVC:viewController titleImageData:props[@"titleImage"]];
   
   NSArray *leftButtons = props[@"leftButtons"];
   if (leftButtons)
@@ -84,7 +84,7 @@ NSString const *CALLBACK_ASSOCIATED_ID = @"RCCNavigationController.CALLBACK_ASSO
     NSString *title = actionParams[@"title"];
     if (title) viewController.title = title;
     
-    [self setTitleIamgeForVC:viewController titleImageData:actionParams[@"titleImage"]];
+    [self setTitleImageForVC:viewController titleImageData:actionParams[@"titleImage"]];
     
     NSString *backButtonTitle = actionParams[@"backButtonTitle"];
     if (backButtonTitle)
@@ -152,7 +152,7 @@ NSString const *CALLBACK_ASSOCIATED_ID = @"RCCNavigationController.CALLBACK_ASSO
     NSString *title = actionParams[@"title"];
     if (title) viewController.title = title;
     
-    [self setTitleIamgeForVC:viewController titleImageData:actionParams[@"titleImage"]];
+    [self setTitleImageForVC:viewController titleImageData:actionParams[@"titleImage"]];
     
     NSArray *leftButtons = actionParams[@"leftButtons"];
     if (leftButtons)
@@ -193,7 +193,7 @@ NSString const *CALLBACK_ASSOCIATED_ID = @"RCCNavigationController.CALLBACK_ASSO
   
   if ([performAction isEqualToString:@"setTitleImage"])
   {
-    [self setTitleIamgeForVC:self.topViewController titleImageData:actionParams[@"titleImage"]];
+    [self setTitleImageForVC:self.topViewController titleImageData:actionParams[@"titleImage"]];
     return;
   }
   
@@ -283,7 +283,7 @@ NSString const *CALLBACK_ASSOCIATED_ID = @"RCCNavigationController.CALLBACK_ASSO
   }
 }
 
--(void)setTitleIamgeForVC:(UIViewController*)viewController titleImageData:(id)titleImageData
+-(void)setTitleImageForVC:(UIViewController*)viewController titleImageData:(id)titleImageData
 {
   if (!titleImageData || [titleImageData isEqual:[NSNull null]])
   {


### PR DESCRIPTION
Just adds the `setTitleImage` function to NavigationControllerIOS, for which the action already exists in RCCNavigationController (and also exists in the react-native-navigation API layer).

Also fixes a typo in the RCCNavigationController method to do that (`setTitleIamgeForVC:` to `setTitleImageForVC:`).

Let me know if you'd prefer two separate PRs for those, and whether its worth adding the `setTitleImage` API to the readme.
