### PR TITLE
Set VC's title independent from possible tab bar button label

### DIFF
--- a/ios/RCCNavigationController.m
+++ b/ios/RCCNavigationController.m
@@ -187,7 +187,7 @@ NSString const *CALLBACK_ASSOCIATED_ID = @"RCCNavigationController.CALLBACK_ASSO
   if ([performAction isEqualToString:@"setTitle"])
   {
     NSString *title = actionParams[@"title"];
-    if (title) self.topViewController.title = title;
+    if (title) self.topViewController.navigationItem.title = title;
     return;
   }
   


### PR DESCRIPTION
Makes `setTitle` set the view controller title through `navigationItem` to prevent interference with a possible tab bar label.

Fixes https://github.com/wix/react-native-navigation/issues/113.

Using `.navigationItem.title` overrides the `title` property of a view controller (which is automatically set by the tab bar controller to be the tab button title) when displaying it in the nav bar. See "The Middle Item" here: https://developer.apple.com/library/ios/documentation/UIKit/Reference/UINavigationController_Class

As far as I can tell, no other actions that change the title (push/reset/etc) should need this, as they either don't apply to a tab bar controller's root element, or they replace it with a new VC entirely.
