### PR TITLE
- Vertically center tab icon if there is no “label”

### DIFF
--- a/ios/RCCTabBarController.m
+++ b/ios/RCCTabBarController.m
@@ -91,8 +91,17 @@
     id selectedIcon = tabItemLayout[@"props"][@"selectedIcon"];
     if (selectedIcon) iconImageSelected = [RCTConvert UIImage:selectedIcon];
 
-    viewController.tabBarItem = [[UITabBarItem alloc] initWithTitle:title image:iconImage tag:0];
-    viewController.tabBarItem.selectedImage = iconImageSelected;
+    if (title) {
+      viewController.tabBarItem = [[UITabBarItem alloc] initWithTitle:title image:iconImage tag:0];
+      viewController.tabBarItem.selectedImage = iconImageSelected;
+    } else {
+      UITabBarItem *tabItem = [[UITabBarItem alloc] init];
+      viewController.tabBarItem = tabItem;
+      tabItem.image = iconImage;
+      tabItem.tag = 0;
+      tabItem.imageInsets = UIEdgeInsetsMake(6, 0, -6, 0);
+      viewController.tabBarItem.selectedImage = iconImageSelected;
+    }
     
     if (buttonColor)
     {


### PR DESCRIPTION
This is a small 'fix' in order to vertically centre icons if there is a missing label. The outcome of is illustrated in the image below. Ideally this is probably going to require a new flag on each tab, but usually it's a UX decision to either have labels or not. This just centres icons if there is no label.

<img width="373" alt="vertically-centered" src="https://cloud.githubusercontent.com/assets/8967148/16983184/012335e0-4eb7-11e6-9370-d95e319d2581.png">
