### PR TITLE
Add support for background/shadow image in NavBar (iOS only)

### DIFF
--- a/ios/RCCViewController.m
+++ b/ios/RCCViewController.m
@@ -218,7 +218,7 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
   
     id shadowImage = self.navigatorStyle[@"shadowImage"];
     if (shadowImage) {
-        UIImage *img = [[RCTConvert UIImage:backgroundImage] stretchableImageWithLeftCapWidth:0 topCapHeight:0];
+        UIImage *img = [[RCTConvert UIImage:shadowImage] stretchableImageWithLeftCapWidth:0 topCapHeight:0];
         [viewController.navigationController.navigationBar setShadowImage:img];
     }
     

--- a/ios/RCCViewController.m
+++ b/ios/RCCViewController.m
@@ -217,7 +217,7 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
     }
   
     id shadowImage = self.navigatorStyle[@"shadowImage"];
-    if (backgroundImage) {
+    if (shadowImage) {
         UIImage *img = [[RCTConvert UIImage:backgroundImage] stretchableImageWithLeftCapWidth:0 topCapHeight:0];
         [viewController.navigationController.navigationBar setShadowImage:img];
     }

--- a/ios/RCCViewController.m
+++ b/ios/RCCViewController.m
@@ -206,6 +206,22 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
         [viewController.navigationController.navigationBar setTitleTextAttributes:nil];
     }
     
+    id backgroundImage = self.navigatorStyle[@"backgroundImage"];
+    if (backgroundImage) {
+        UIImage *img = [[RCTConvert UIImage:backgroundImage] stretchableImageWithLeftCapWidth:0 topCapHeight:0];
+
+        [viewController.navigationController.navigationBar setBackgroundImage:img forBarPosition:UIBarPositionAny barMetrics:UIBarMetricsDefault];
+        [viewController.navigationController.navigationBar setBackgroundImage:img forBarPosition:UIBarPositionAny barMetrics:UIBarMetricsCompact];
+        [viewController.navigationController.navigationBar setBackgroundImage:img forBarPosition:UIBarPositionAny barMetrics:UIBarMetricsDefaultPrompt];
+        [viewController.navigationController.navigationBar setBackgroundImage:img forBarPosition:UIBarPositionAny barMetrics:UIBarMetricsCompactPrompt];
+    }
+  
+    id shadowImage = self.navigatorStyle[@"shadowImage"];
+    if (backgroundImage) {
+        UIImage *img = [[RCTConvert UIImage:backgroundImage] stretchableImageWithLeftCapWidth:0 topCapHeight:0];
+        [viewController.navigationController.navigationBar setShadowImage:img];
+    }
+    
     NSString *navBarButtonColor = self.navigatorStyle[@"navBarButtonColor"];
     if (navBarButtonColor)
     {


### PR DESCRIPTION
Small change to allow for custom background and/or shadow image on iOS's Navigation Bar.
I have no clue how one would go about to implement this on Android as I have next-to-none experience working on that platform. 😅
