### PR TITLE
fix the bug of implicit declaration of function 'objc_setassociatedob…

### DIFF
--- a/ios/RCCNavigationController.m
+++ b/ios/RCCNavigationController.m
@@ -3,6 +3,7 @@
 #import "RCCManager.h"
 #import "RCTEventDispatcher.h"
 #import "RCTConvert.h"
+#import <objc/runtime.h>
 
 @implementation RCCNavigationController
 


### PR DESCRIPTION
fix the bug of implicit declaration of function 'objc_setassociatedobject' is invalid in c99
