### PR TITLE
Feature/adjust insets

### DIFF
--- a/README.md
+++ b/README.md
@@ -605,7 +605,8 @@ All styles are optional, this is the format of the style object:
   tabBarHidden: false, // make the screen content hide the tab bar (remembered across pushes)
   statusBarHideWithNavBar: false // hide the status bar if the nav bar is also hidden, useful for navBarHidden:true
   statusBarHidden: false, // make the status bar hidden regardless of nav bar state
-  statusBarTextColorScheme: 'dark' // text color of status bar, 'dark' / 'light' (remembered across pushes)
+  statusBarTextColorScheme: 'dark', // text color of status bar, 'dark' / 'light' (remembered across pushes)
+  autoAdjustScrollViewInsets: true, // make the screen adjust any scroll view insets to account for the tab bar translucency
 }
 ```
 

--- a/ios/RCCNavigationController.m
+++ b/ios/RCCNavigationController.m
@@ -75,6 +75,7 @@ NSString const *CALLBACK_ASSOCIATED_ID = @"RCCNavigationController.CALLBACK_ASSO
       [mergedStyle removeObjectForKey:@"navBarBlur"];
       [mergedStyle removeObjectForKey:@"navBarTranslucent"];
       [mergedStyle removeObjectForKey:@"statusBarHideWithNavBar"];
+      [mergedStyle removeObjectForKey:@"autoAdjustScrollViewInsets"];
       
       [mergedStyle addEntriesFromDictionary:navigatorStyle];
       navigatorStyle = mergedStyle;

--- a/ios/RCCViewController.m
+++ b/ios/RCCViewController.m
@@ -137,7 +137,7 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
   self.view = reactView;
   
   self.edgesForExtendedLayout = UIRectEdgeNone; // default
-  self.automaticallyAdjustsScrollViewInsets = NO; // default
+  self.automaticallyAdjustsScrollViewInsets = false; // default
   
   self.navigatorStyle = [NSMutableDictionary dictionaryWithDictionary:navigatorStyle];
   
@@ -357,7 +357,10 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
     {
         viewController.edgesForExtendedLayout &= ~UIRectEdgeBottom;
     }
-    
+  
+    NSNumber *autoAdjustsScrollViewInsets = self.navigatorStyle[@"autoAdjustScrollViewInsets"];
+    viewController.automaticallyAdjustsScrollViewInsets = autoAdjustsScrollViewInsets ? [autoAdjustsScrollViewInsets boolValue] : false;
+  
     NSNumber *removeNavBarBorder = self.navigatorStyle[@"navBarNoBorder"];
     BOOL removeNavBarBorderBool = removeNavBarBorder ? [removeNavBarBorder boolValue] : NO;
     if(removeNavBarBorderBool)
@@ -414,37 +417,13 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
 - (void)setStyleOnInit
 {
     NSNumber *tabBarHidden = self.navigatorStyle[@"tabBarHidden"];
-    BOOL tabBarHiddenBool = tabBarHidden ? [tabBarHidden boolValue] : NO;
-    if (tabBarHiddenBool)
-    {
-        self._hidesBottomBarWhenPushed = YES;
-    }
-    else
-    {
-        self._hidesBottomBarWhenPushed = NO;
-    }
+    self._hidesBottomBarWhenPushed = tabBarHidden ? [tabBarHidden boolValue] : false;
     
     NSNumber *statusBarHideWithNavBar = self.navigatorStyle[@"statusBarHideWithNavBar"];
-    BOOL statusBarHideWithNavBarBool = statusBarHideWithNavBar ? [statusBarHideWithNavBar boolValue] : NO;
-    if (statusBarHideWithNavBarBool)
-    {
-        self._statusBarHideWithNavBar = YES;
-    }
-    else
-    {
-        self._statusBarHideWithNavBar = NO;
-    }
+    self._statusBarHideWithNavBar = statusBarHideWithNavBar ? [statusBarHideWithNavBar boolValue] : false;
     
     NSNumber *statusBarHidden = self.navigatorStyle[@"statusBarHidden"];
-    BOOL statusBarHiddenBool = statusBarHidden ? [statusBarHidden boolValue] : NO;
-    if (statusBarHiddenBool)
-    {
-        self._statusBarHidden = YES;
-    }
-    else
-    {
-        self._statusBarHidden = NO;
-    }
+    self._statusBarHidden = statusBarHidden ? [statusBarHidden boolValue] : false;
 }
 
 - (BOOL)hidesBottomBarWhenPushed


### PR DESCRIPTION
This adds support for setting automaticallyAdjustsScrollViewInsets on each instance of RCCViewController via an additional parameter in the navigatorStyle dictionary. This is required for when the user wants their content to scroll under the navigation bar, but not start under the navigation bar upon initially appearing. See attached screenshots:

![simulator screen shot 31 aug 2016 11 55 04](https://cloud.githubusercontent.com/assets/9033831/18126168/cfc8b11a-6f71-11e6-8642-5428d6f6b701.png)
![simulator screen shot 31 aug 2016 11 55 09](https://cloud.githubusercontent.com/assets/9033831/18126167/cfab3d4c-6f71-11e6-8bdd-85a4c2750224.png)
