### PR TITLE
Lets add a `screenBackgroundColor` in navigatorStyle

### DIFF
--- a/ios/RCCViewController.m
+++ b/ios/RCCViewController.m
@@ -194,6 +194,14 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
 
 -(void)setStyleOnAppearForViewController:(UIViewController*)viewController
 {
+    
+    NSString *screenBackgroundColor = self.navigatorStyle[@"screenBackgroundColor"];
+    if (screenBackgroundColor)
+    {
+        UIColor *color = screenBackgroundColor != (id)[NSNull null] ? [RCTConvert UIColor:screenBackgroundColor] : nil;
+        self.view.backgroundColor = color;
+    }
+    
     NSString *navBarBackgroundColor = self.navigatorStyle[@"navBarBackgroundColor"];
     if (navBarBackgroundColor)
     {


### PR DESCRIPTION
(c) https://github.com/MattDavies/react-native-controllers/commit/fb5dec7d4e53026cd11617ac86b093e4397c0df0

By default the view backgroundColor is white. This produces a white flickering for some of us when using dark backgroundColor in the <View />, because when we use push a new RootView is created and React styles applies not directly. So what happens is the following:

0. Navigator takes the registered component
1. Create a new ReactView, which has by default backgroundColor white!
2. Applies the navigation
<Here we see the flickering>
3. React styles will get applied

This commit adds a new navigatorStyle property `screenBackgroundColor`, which will get applied directly to the view as the backgroundColor, before React applies the backgroundColor from the actual styles.